### PR TITLE
GitHub Actionsワークフローを最新のコードベースに合わせて更新

### DIFF
--- a/.github/workflows/relearn.yml
+++ b/.github/workflows/relearn.yml
@@ -9,27 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [21.6.0]
+        node-version: [22.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: node_modules
-          key: node-dependencies-${{ hashFiles('yarn.lock') }}
+          key: node-dependencies-${{ hashFiles('package-lock.json') }}
       - name: Install JavaScript dependencies
         run: |
-          yarn install
+          npm ci
       - name: Start
         run: |
-         yarn build && yarn start
+         npm run build && npm start
         env:
-          DBX_CLIENT_ID: ${{ secrets.DBX_CLIENT_ID }}
-          DBX_CLIENT_SECRET: ${{ secrets.DBX_CLIENT_SECRET }}
-          DBX_REFRESH_TOKEN: ${{ secrets.DBX_REFRESH_TOKEN }}
-          DBX_TARGET_PATH: ${{ secrets.DBX_TARGET_PATH }}
+          GOOGLE_DRIVE_CREDENTIALS: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- GitHub Actionsのワークフロー設定を現在のコードベース（relearn v2）に合わせて更新
- Node.js 22.x、npm、Google Driveへの移行を反映

## 主な変更点

### GitHub Actions (.github/workflows/relearn.yml)
- Node.jsバージョンを21.6.0から22.xに更新
- パッケージマネージャーをyarnからnpmに変更
  - `yarn install` → `npm ci`
  - `yarn build && yarn start` → `npm run build && npm start`
  - キャッシュキーを`yarn.lock` → `package-lock.json`に変更
- ストレージをDropboxからGoogle Driveに変更
  - 削除: `DBX_CLIENT_ID`, `DBX_CLIENT_SECRET`, `DBX_REFRESH_TOKEN`, `DBX_TARGET_PATH`
  - 追加: `GOOGLE_DRIVE_CREDENTIALS`, `GOOGLE_DRIVE_FOLDER_ID`
- GitHubアクションをv3からv4に更新

### その他
- `.nvmrc`: 22.12.0に更新
- `.husky/pre-commit`: `yarn lint-staged` → `npx lint-staged`
- `.env.template`: Google Drive関連の環境変数を追加
- `.gitignore`: `.claude/`ディレクトリを追加
- `package-lock.json`: 新規追加

## Test plan

- [ ] GitHub Actionsのシークレットに以下を設定
  - `GOOGLE_DRIVE_CREDENTIALS`
  - `GOOGLE_DRIVE_FOLDER_ID`
  - `SLACK_WEBHOOK_URL`
- [ ] ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)